### PR TITLE
Fix rotatable logs

### DIFF
--- a/src/main/java/com/whammich/sstow/block/BlockPetrified.java
+++ b/src/main/java/com/whammich/sstow/block/BlockPetrified.java
@@ -1,7 +1,9 @@
 package com.whammich.sstow.block;
 
-import java.util.List;
-
+import com.whammich.sstow.utils.Reference;
+import com.whammich.sstow.utils.Register;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.block.BlockRotatedPillar;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -10,11 +12,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 
-import com.whammich.sstow.utils.Reference;
-import com.whammich.sstow.utils.Register;
-
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
+import java.util.List;
 
 public class BlockPetrified extends BlockRotatedPillar {
 	@SideOnly(Side.CLIENT)
@@ -24,27 +22,23 @@ public class BlockPetrified extends BlockRotatedPillar {
 
 	public BlockPetrified() {
 		super(Material.rock);
-		setCreativeTab(Register.CREATIVE_TAB);
-		setLightOpacity(255);
-		useNeighborBrightness = true;
-		blockHardness = 3.0F;
-		blockResistance = 3.0F;
-		setBlockName("petrified_log");
+        setBlockName("petrified_log");
+        setCreativeTab(Register.CREATIVE_TAB);
+        setLightOpacity(255);
+        useNeighborBrightness = true;
+        blockHardness = 3.0F;
+        blockResistance = 3.0F;
 	}
 
-	public static final String[] names = new String[] { "oak", "spruce",
-			"birch", "jungle", "acacia", "big_oak" };
+	public static final String[] names = { "oak", "spruce", "birch", "jungle" };
 
 	@Override
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@SideOnly(Side.CLIENT)
 	public void getSubBlocks(Item item, CreativeTabs tabs, List list) {
-		list.add(new ItemStack(item, 1, 0));
-		list.add(new ItemStack(item, 1, 1));
-		list.add(new ItemStack(item, 1, 2));
-		list.add(new ItemStack(item, 1, 3));
-		list.add(new ItemStack(item, 1, 4));
-		list.add(new ItemStack(item, 1, 5));
+        for (int i = 0; i < names.length; i++) {
+            list.add(new ItemStack(item, 1, i));
+        }
 	}
 
 	@Override
@@ -54,10 +48,8 @@ public class BlockPetrified extends BlockRotatedPillar {
 		this.topIcon = new IIcon[names.length];
 
 		for (int i = 0; i < this.sideIcon.length; ++i) {
-			this.sideIcon[i] = iconRegister.registerIcon(Reference.MOD_ID
-					+ ":petrified_logs/petrified_log_" + names[i]);
-			this.topIcon[i] = iconRegister.registerIcon(Reference.MOD_ID
-					+ ":petrified_logs/petrified_log_" + names[i] + "_top");
+			this.sideIcon[i] = iconRegister.registerIcon(Reference.MOD_ID + ":petrified_logs/petrified_log_" + names[i]);
+			this.topIcon[i] = iconRegister.registerIcon(Reference.MOD_ID + ":petrified_logs/petrified_log_" + names[i] + "_top");
 		}
 	}
 
@@ -77,5 +69,4 @@ public class BlockPetrified extends BlockRotatedPillar {
 	public IIcon getTopIcon(int side) {
 		return this.topIcon[side % this.topIcon.length];
 	}
-
 }

--- a/src/main/java/com/whammich/sstow/block/BlockPetrified2.java
+++ b/src/main/java/com/whammich/sstow/block/BlockPetrified2.java
@@ -1,0 +1,72 @@
+package com.whammich.sstow.block;
+
+import com.whammich.sstow.utils.Reference;
+import com.whammich.sstow.utils.Register;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.block.BlockRotatedPillar;
+import net.minecraft.block.material.Material;
+import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.IIcon;
+
+import java.util.List;
+
+public class BlockPetrified2 extends BlockRotatedPillar {
+    @SideOnly(Side.CLIENT)
+    protected IIcon[] sideIcon;
+    @SideOnly(Side.CLIENT)
+    protected IIcon[] topIcon;
+
+    public BlockPetrified2() {
+        super(Material.rock);
+        setBlockName("petrified_log");
+        setCreativeTab(Register.CREATIVE_TAB);
+        setLightOpacity(255);
+        useNeighborBrightness = true;
+        blockHardness = 3.0F;
+        blockResistance = 3.0F;
+    }
+
+    public static final String[] names = { "acacia", "big_oak" };
+
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SideOnly(Side.CLIENT)
+    public void getSubBlocks(Item item, CreativeTabs tabs, List list) {
+        for (int i = 0; i < names.length; i++) {
+            list.add(new ItemStack(item, 1, i));
+        }
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public void registerBlockIcons(IIconRegister iconRegister) {
+        this.sideIcon = new IIcon[names.length];
+        this.topIcon = new IIcon[names.length];
+
+        for (int i = 0; i < this.sideIcon.length; ++i) {
+            this.sideIcon[i] = iconRegister.registerIcon(Reference.MOD_ID + ":petrified_logs/petrified_log_" + names[i]);
+            this.topIcon[i] = iconRegister.registerIcon(Reference.MOD_ID + ":petrified_logs/petrified_log_" + names[i] + "_top");
+        }
+    }
+
+    @Override
+    public int damageDropped(int meta) {
+        return meta;
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public IIcon getSideIcon(int side) {
+        return this.sideIcon[side % this.sideIcon.length];
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public IIcon getTopIcon(int side) {
+        return this.topIcon[side % this.topIcon.length];
+    }
+}

--- a/src/main/java/com/whammich/sstow/item/blocks/ItemBlockPetrified.java
+++ b/src/main/java/com/whammich/sstow/item/blocks/ItemBlockPetrified.java
@@ -1,11 +1,11 @@
 package com.whammich.sstow.item.blocks;
 
+import com.whammich.sstow.block.BlockPetrified;
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 
 public class ItemBlockPetrified extends ItemBlock {
-	String[] names = { "oak", "spruce", "birch", "jungle", "acacia", "big_oak" };
 
 	public ItemBlockPetrified(Block block) {
 		super(block);
@@ -14,11 +14,11 @@ public class ItemBlockPetrified extends ItemBlock {
 	
 	@Override
 	public String getUnlocalizedName(ItemStack stack) {
-		return getUnlocalizedName() + "." + names[stack.getItemDamage() % names.length];
+		return getUnlocalizedName() + "." + BlockPetrified.names[stack.getItemDamage() % BlockPetrified.names.length];
 	}
 
 	@Override
-	public int getMetadata(int par1) {
-		return par1;
+	public int getMetadata(int meta) {
+		return meta;
 	}
 }

--- a/src/main/java/com/whammich/sstow/item/blocks/ItemBlockPetrified2.java
+++ b/src/main/java/com/whammich/sstow/item/blocks/ItemBlockPetrified2.java
@@ -1,0 +1,24 @@
+package com.whammich.sstow.item.blocks;
+
+import com.whammich.sstow.block.BlockPetrified2;
+import net.minecraft.block.Block;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
+
+public class ItemBlockPetrified2 extends ItemBlock {
+
+    public ItemBlockPetrified2(Block block) {
+        super(block);
+        setHasSubtypes(true);
+    }
+
+    @Override
+    public String getUnlocalizedName(ItemStack stack) {
+        return getUnlocalizedName() + "." + BlockPetrified2.names[stack.getItemDamage() % BlockPetrified2.names.length];
+    }
+
+    @Override
+    public int getMetadata(int meta) {
+        return meta;
+    }
+}

--- a/src/main/java/com/whammich/sstow/utils/Register.java
+++ b/src/main/java/com/whammich/sstow/utils/Register.java
@@ -1,5 +1,17 @@
 package com.whammich.sstow.utils;
 
+import com.whammich.sstow.SSTheOldWays;
+import com.whammich.sstow.block.*;
+import com.whammich.sstow.enchantment.EnchantmentSoulStealer;
+import com.whammich.sstow.guihandler.GuiHandler;
+import com.whammich.sstow.item.*;
+import com.whammich.sstow.item.blocks.ItemBlockPetrified;
+import com.whammich.sstow.item.blocks.ItemBlockPetrified2;
+import com.whammich.sstow.tileentity.TileEntityCage;
+import com.whammich.sstow.tileentity.TileEntityForge;
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.network.NetworkRegistry;
+import cpw.mods.fml.common.registry.GameRegistry;
 import net.minecraft.block.Block;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.init.Blocks;
@@ -12,38 +24,12 @@ import net.minecraftforge.oredict.OreDictionary;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 import net.minecraftforge.oredict.ShapelessOreRecipe;
 
-import com.whammich.sstow.SSTheOldWays;
-import com.whammich.sstow.block.BlockCage;
-import com.whammich.sstow.block.BlockForge;
-import com.whammich.sstow.block.BlockPetrified;
-import com.whammich.sstow.block.BlockSoulium;
-import com.whammich.sstow.block.BlockXenolith;
-import com.whammich.sstow.enchantment.EnchantmentSoulStealer;
-import com.whammich.sstow.guihandler.GuiHandler;
-import com.whammich.sstow.item.ItemMaterials;
-import com.whammich.sstow.item.ItemAxeSoul;
-import com.whammich.sstow.item.ItemHoeSoul;
-import com.whammich.sstow.item.ItemPickaxeSoul;
-import com.whammich.sstow.item.ItemShardSoul;
-import com.whammich.sstow.item.ItemSpadeSoul;
-import com.whammich.sstow.item.ItemSwordSoul;
-import com.whammich.sstow.item.ItemfixedAchievement;
-import com.whammich.sstow.item.blocks.ItemBlockPetrified;
-import com.whammich.sstow.tileentity.TileEntityCage;
-import com.whammich.sstow.tileentity.TileEntityForge;
-
-import cpw.mods.fml.common.Loader;
-import cpw.mods.fml.common.network.NetworkRegistry;
-import cpw.mods.fml.common.registry.GameRegistry;
-
 public class Register {
 	// Tool material for the soul tools/sword
-	public static ToolMaterial SOULIUM = EnumHelper.addToolMaterial("SOULIUM",
-			3, 3122, 12.0F, 6F, 30);
+	public static ToolMaterial SOULIUM = EnumHelper.addToolMaterial("SOULIUM", 3, 3122, 12.0F, 6F, 30);
 
 	// Setting up the enchantment details from the config
-	public static Enchantment SOUL_STEALER = new EnchantmentSoulStealer(
-			Config.ENCHANT_ID, Config.ENCHANT_WEIGHT);
+	public static Enchantment SOUL_STEALER = new EnchantmentSoulStealer(Config.ENCHANT_ID, Config.ENCHANT_WEIGHT);
 
 	// Set the creative tab
 	public static SoulShardTab CREATIVE_TAB = new SoulShardTab();
@@ -60,18 +46,16 @@ public class Register {
 
 	// Set up the mod blocks
 	public static Block BlockCage = new BlockCage();
-	public static Block BlockForge = new BlockForge(false)
-			.setCreativeTab(CREATIVE_TAB);
-	public static Block BlockForgeActive = new BlockForge(true)
-			.setBlockName("sstow.forge_block_active");;
+	public static Block BlockForge = new BlockForge(false).setCreativeTab(CREATIVE_TAB);
+	public static Block BlockForgeActive = new BlockForge(true).setBlockName("sstow.forge_block_active");
 	public static Block BlockSoulium = new BlockSoulium();
 	public static Block BlockXenolith = new BlockXenolith();
 
-	public static Block BlockPetrified;
+	public static Block BlockPetrified = new BlockPetrified();
+    public static Block BlockPetrified2 = new BlockPetrified2();
 
 	public static void registerObjs() {
-		NetworkRegistry.INSTANCE.registerGuiHandler(SSTheOldWays.modInstance,
-				new GuiHandler());
+		NetworkRegistry.INSTANCE.registerGuiHandler(SSTheOldWays.modInstance, new GuiHandler());
 
 		registerItems();
 		registerBlocks();
@@ -86,7 +70,6 @@ public class Register {
 			GameRegistry.registerItem(ItemFixedDummy, "ItemFixedDummy");
 
 		GameRegistry.registerItem(ItemMaterials, "ItemMaterialsSoul");
-
 		GameRegistry.registerItem(ItemSwordSoul, "ItemSwordSoul");
 		GameRegistry.registerItem(ItemPickaxeSoul, "ItemPickaxeSoul");
 		GameRegistry.registerItem(ItemAxeSoul, "ItemAxeSoul");
@@ -97,82 +80,49 @@ public class Register {
 
 	private static void registerBlocks() {
 		GameRegistry.registerBlock(BlockForge, "BlockForge");
-		GameRegistry.registerBlock(BlockForgeActive,
-				BlockForgeActive.getUnlocalizedName());
+		GameRegistry.registerBlock(BlockForgeActive, BlockForgeActive.getUnlocalizedName());
 		GameRegistry.registerBlock(BlockSoulium, "sstow_soulium_block");
 		GameRegistry.registerBlock(BlockCage, "sstow_soul_cage");
 		GameRegistry.registerBlock(BlockXenolith, "sstow_xenolith");
-
-		BlockPetrified = new BlockPetrified();
-		GameRegistry.registerBlock(BlockPetrified, ItemBlockPetrified.class,
-				"PetrifiedLog");
+		GameRegistry.registerBlock(BlockPetrified, ItemBlockPetrified.class, "BlockPetrifiedLog");
+		GameRegistry.registerBlock(BlockPetrified2, ItemBlockPetrified2.class, "BlockPetrifiedLog2");
 	}
 
 	private static void registerOreDictEntries() {
-		OreDictionary.registerOre("nuggetIron", new ItemStack(ItemMaterials, 1,
-				0));
-		OreDictionary.registerOre("nuggetSoulium", new ItemStack(ItemMaterials,
-				1, 1));
-		OreDictionary.registerOre("ingotSoulium", new ItemStack(ItemMaterials,
-				1, 2));
-		OreDictionary.registerOre("dustVile",
-				new ItemStack(ItemMaterials, 1, 3));
-		OreDictionary.registerOre("essenceCorrupted", new ItemStack(
-				ItemMaterials, 1, 4));
+		OreDictionary.registerOre("nuggetIron", new ItemStack(ItemMaterials, 1, 0));
+		OreDictionary.registerOre("nuggetSoulium", new ItemStack(ItemMaterials, 1, 1));
+		OreDictionary.registerOre("ingotSoulium", new ItemStack(ItemMaterials, 1, 2));
+		OreDictionary.registerOre("dustVile", new ItemStack(ItemMaterials, 1, 3));
+		OreDictionary.registerOre("essenceCorrupted", new ItemStack(ItemMaterials, 1, 4));
 	}
 
 	private static void registerTileEntities() {
-		GameRegistry.registerTileEntity(TileEntityForge.class,
-				"sstow_soul_forge_tile");
-		GameRegistry.registerTileEntity(TileEntityCage.class,
-				"sstow_soul_cage_tile");
+		GameRegistry.registerTileEntity(TileEntityForge.class, "sstow_soul_forge_tile");
+		GameRegistry.registerTileEntity(TileEntityCage.class, "sstow_soul_cage_tile");
 	}
 
 	private static void registerRecipes() {
-		GameRegistry.addRecipe(new ShapelessOreRecipe(new ItemStack(
-				ItemMaterials, 9, 2), BlockSoulium));
-		GameRegistry.addRecipe(new ShapelessOreRecipe(new ItemStack(
-				ItemMaterials, 9, 1), "ingotSoulium"));
-		GameRegistry.addRecipe(new ShapelessOreRecipe(new ItemStack(
-				ItemMaterials, 9, 0), "ingotIron"));
+		GameRegistry.addRecipe(new ShapelessOreRecipe(new ItemStack(ItemMaterials, 9, 2), BlockSoulium));
+		GameRegistry.addRecipe(new ShapelessOreRecipe(new ItemStack(ItemMaterials, 9, 1), "ingotSoulium"));
+		GameRegistry.addRecipe(new ShapelessOreRecipe(new ItemStack(ItemMaterials, 9, 0), "ingotIron"));
 
-		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(BlockForge),
-				"SSS", "SCS", "OOO", 'S', "cobblestone", 'C',
-				"essenceCorrupted", 'O', Blocks.obsidian));
-		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(ItemMaterials,
-				1, 2), "AAA", "AAA", "AAA", 'A', "nuggetSoulium"));
-		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(
-				Items.iron_ingot), "AAA", "AAA", "AAA", 'A', "nuggetIron"));
-		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(BlockSoulium),
-				"AAA", "AAA", "AAA", 'A', "ingotSoulium"));
-		GameRegistry.addRecipe(new ShapedOreRecipe(
-				new ItemStack(ItemSwordSoul), "A", "A", "B", 'A',
-				"ingotSoulium", 'B', "ingotIron"));
-		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(
-				ItemPickaxeSoul), "AAA", "CBC", "CBC", 'A', "ingotSoulium",
-				'B', "ingotIron"));
-		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(ItemAxeSoul),
-				"AA", "AB", "CB", 'A', "ingotSoulium", 'B', "ingotIron"));
-		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(ItemHoeSoul),
-				"AA", "CB", "CB", 'A', "ingotSoulium", 'B', "ingotIron"));
-		GameRegistry.addRecipe(new ShapedOreRecipe(
-				new ItemStack(ItemSpadeSoul), "A", "B", "B", 'A',
-				"ingotSoulium", 'B', "ingotIron"));
-		GameRegistry
-				.addRecipe(new ShapedOreRecipe(new ItemStack(BlockCage), "SIS",
-						"IXI", "SIS", 'I', Blocks.iron_bars, 'S',
-						"ingotSoulium"));
+		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(BlockForge), "SSS", "SCS", "OOO", 'S', "cobblestone", 'C', "essenceCorrupted", 'O', Blocks.obsidian));
+		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(ItemMaterials, 1, 2), "AAA", "AAA", "AAA", 'A', "nuggetSoulium"));
+		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(Items.iron_ingot), "AAA", "AAA", "AAA", 'A', "nuggetIron"));
+		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(BlockSoulium), "AAA", "AAA", "AAA", 'A', "ingotSoulium"));
+		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(ItemSwordSoul), "A", "A", "B", 'A', "ingotSoulium", 'B', "ingotIron"));
+		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(ItemPickaxeSoul), "AAA", "CBC", "CBC", 'A', "ingotSoulium", 'B', "ingotIron"));
+		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(ItemAxeSoul), "AA", "AB", "CB", 'A', "ingotSoulium", 'B', "ingotIron"));
+		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(ItemHoeSoul), "AA", "CB", "CB", 'A', "ingotSoulium", 'B', "ingotIron"));
+		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(ItemSpadeSoul), "A", "B", "B", 'A', "ingotSoulium", 'B', "ingotIron"));
+		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(BlockCage), "SIS", "IXI", "SIS", 'I', Blocks.iron_bars, 'S', "ingotSoulium"));
 
 		if (Loader.isModLoaded("Natura")) {
-			GameRegistry.addRecipe(new ShapelessOreRecipe(new ItemStack(
-					ItemMaterials, 2, 3), Blocks.soul_sand, "dustGlowstone"));
-			GameRegistry.addSmelting(new ItemStack(ItemMaterials, 1, 3),
-					new ItemStack(ItemMaterials, 1, 4), 0.35F);
+			GameRegistry.addRecipe(new ShapelessOreRecipe(new ItemStack(ItemMaterials, 2, 3), Blocks.soul_sand, "dustGlowstone"));
+			GameRegistry.addSmelting(new ItemStack(ItemMaterials, 1, 3), new ItemStack(ItemMaterials, 1, 4), 0.35F);
 		} else {
-			GameRegistry.addRecipe(new ShapelessOreRecipe(new ItemStack(
-					ItemMaterials, 1, 4), "dustGlowstone", "dustVile"));
-			GameRegistry.addSmelting(Blocks.soul_sand, new ItemStack(
-					ItemMaterials, 1, 3), 0.35F);
+			GameRegistry.addRecipe(new ShapelessOreRecipe(new ItemStack(ItemMaterials, 1, 4), "dustGlowstone", "dustVile"));
+			GameRegistry.addSmelting(Blocks.soul_sand, new ItemStack(ItemMaterials, 1, 3), 0.35F);
 		}
 	}
 }


### PR DESCRIPTION
Since rotation takes Meta, we can only have 4 logs per ID. I split it up
into 2 different blocks (Just like Vanilla)