### PR TITLE
Fix for spawning Mobs (Entity Initilialization)

### DIFF
--- a/src/main/java/com/whammich/sstow/utils/EntityMapper.java
+++ b/src/main/java/com/whammich/sstow/utils/EntityMapper.java
@@ -57,6 +57,14 @@ public final class EntityMapper {
 			VillagerRegistry.applyRandomTrade(villager, villager.worldObj.rand);
 			return villager;
 		}
-		return (EntityLiving) EntityList.createEntityByName(ent, world);
+		
+		EntityLiving spawnedEntity = (EntityLiving)EntityList.createEntityByName(ent, world);  
+		
+		// This will ensure custom handlers from other mods
+		// that have custom initialization logic will be called
+		// properly.
+		spawnedEntity.onSpawnWithEgg(null);
+		
+		return spawnedEntity;
 	}
 }


### PR DESCRIPTION
This will fix spawning mobs from other mods that may have sub-types per entity class
... such as MoCreatures.

In my case i wondered why an Ogre Soulshard would just spawn "Green Ogre's" ..

After comparing the spawn-logic with MFR's Autospawner code, i saw that the Soulcage won't call 
onSpawnWithEgg()  (don't be confused by the method's name.. :/)

For MFR's Code See:
https://github.com/skyboy/MineFactoryReloaded/blob/master/src/powercrystals/minefactoryreloaded/tile/machine/TileEntityAutoSpawner.java#L171
